### PR TITLE
Update now.redirect.json to work with Now 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Currently configured with GITHUB_TOKEN value.
 ### To Production
 The production is hosted using [now.sh](https://now.sh).
 The process is manual and requires deploying two now apps. You can do that by installing now and deploying the separate now.json files.
-To speed this up you can make sure now is installed globally before running `npx yarn global add now`.
+To speed this up you can make sure now is installed globally before running `yarn global add now`.
 This will deploy what is currently in your dist folder, so make sure you have a build in `dist/` that you want to deploy.
 The Licence in `now.redirect.json` will never actually be served, we just need now.sh to not try and run yarn build, as yarn build will fail.
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Currently configured with GITHUB_TOKEN value.
 ### To Production
 The production is hosted using [now.sh](https://now.sh).
 The process is manual and requires deploying two now apps. You can do that by installing now and deploying the separate now.json files.
-To speed this up you can make sure now is installed globally before running npx `yarn global add now`.
+To speed this up you can make sure now is installed globally before running `npx yarn global add now`.
 This will deploy what is currently in your dist folder, so make sure you have a build in `dist/` that you want to deploy.
+The Licence in `now.redirect.json` will never actually be served, we just need now.sh to not try and run yarn build, as yarn build will fail.
 
 Quickstart:
 ```bash

--- a/now.redirect.json
+++ b/now.redirect.json
@@ -4,7 +4,6 @@
     "alias": ["hopestories.org.uk"],
     "builds": [
         {
-            "//": "License will never actually be served, we just need now.sh to not try and run yarn build, as yarn build will fail.",
             "src": "LICENSE",
             "use": "@now/static"
         }


### PR DESCRIPTION
Fixes #99 

## Description

- Makes the deploy work with Now v2.0
- Moves the comment into the readme

@neontribe/contemplating-action
